### PR TITLE
handle file permission of unarchived content

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,7 @@
 deploy_archive_app_name: "appname"
 
 deploy_archive_dest: "/opt/{{ deploy_archive_app_name }}"
-deploy_archive_dest_permissions:
-  { folder_permission: "0755", file_permission: "0644" }
+
 deploy_archive_get_url_headers: {}
 deploy_archive_create_user: true
 deploy_archive_appuser:
@@ -36,6 +35,10 @@ deploy_archive_conf:
 #   "some nice config file
 #   multiline "example" with 'weird'
 #   special problematic caracters"
+
+# Define this variable to recursively set permissions on deployed files
+# deploy_archive_dest_permissions:
+#   { folder_permission: "0755", file_permission: "0644" }
 
 # Define this variable to install some dependencies you might have
 # deploy_archive_dependencies: [python3-testing, some_other_package]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@
 deploy_archive_app_name: "appname"
 
 deploy_archive_dest: "/opt/{{ deploy_archive_app_name }}"
+deploy_archive_dest_permissions:
+  { folder_permission: "0755", file_permission: "0644" }
 deploy_archive_get_url_headers: {}
 deploy_archive_create_user: true
 deploy_archive_appuser:
@@ -11,14 +13,14 @@ deploy_archive_appuser:
     group: "{{ deploy_archive_app_name }}",
     shell: "/bin/sh",
     home: "{{ deploy_archive_dest }}",
-    comment: "User to run {{ deploy_archive_app_name }}"
+    comment: "User to run {{ deploy_archive_app_name }}",
   }
 
 deploy_archive_src:
   {
     url: "test.net",
     archive_name: "{{ deploy_archive_app_name }}.tar.gz",
-    checksum: "somechecksum"
+    checksum: "somechecksum",
   }
 
 deploy_archive_systemd_restart: false
@@ -27,9 +29,8 @@ deploy_archive_conf:
   {
     path: "{{ deploy_archive_dest }}",
     filename: "{{ deploy_archive_app_name }}.conf",
-    permission: "0644"
+    permission: "0644",
   }
-
 # Define this variable to activate define the content of a config file
 # deploy_archive_conf_content: |
 #   "some nice config file

--- a/tasks/setup_asset.yml
+++ b/tasks/setup_asset.yml
@@ -44,11 +44,13 @@
 
 - name: Deploy archive | Set directory permissions
   ansible.builtin.command: "find {{ deploy_archive_dest }} -type d -exec chmod {{ deploy_archive_dest_permissions.folder_permission }} {} +"
+  when: deploy_archive_dest_permissions is defined
   tags:
     - molecule-idempotence-notest
 
 - name: Deploy archive | Set file permissions
   ansible.builtin.command: "find {{ deploy_archive_dest }} -type f -exec chmod {{ deploy_archive_dest_permissions.file_permission }} {} +"
+  when: deploy_archive_dest_permissions is defined
   tags:
     - molecule-idempotence-notest
 

--- a/tasks/setup_asset.yml
+++ b/tasks/setup_asset.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ deploy_archive_appuser.name }}"
     group: "{{ deploy_archive_appuser.group }}"
-    mode: '0755'
+    mode: "0755"
 
 - name: Deploy archive | Download
   ansible.builtin.get_url:
@@ -15,7 +15,7 @@
        ternary('sha256:' + deploy_archive_src.checksum, omit) }}
     dest: "{{ deploy_archive_dest }}/{{ deploy_archive_src.archive_name }}"
     headers: "{{ deploy_archive_get_url_headers }}"
-    mode: '0644'
+    mode: "0644"
   when: deploy_archive_src.url is defined
   tags:
     - molecule-idempotence-notest
@@ -27,7 +27,7 @@
       {{ (deploy_archive_src.checksum | length > 0) |
        ternary(deploy_archive_src.checksum, omit) }}
     dest: "{{ deploy_archive_dest }}/{{ deploy_archive_src.archive_name }}"
-    mode: '0644'
+    mode: "0644"
   when: deploy_archive_src.path is defined
   tags:
     - molecule-idempotence-notest
@@ -39,6 +39,16 @@
     owner: "{{ deploy_archive_appuser.name }}"
     group: "{{ deploy_archive_appuser.group }}"
     remote_src: true
+  tags:
+    - molecule-idempotence-notest
+
+- name: Deploy archive | Set directory permissions
+  ansible.builtin.command: "find {{ deploy_archive_dest }} -type d -exec chmod {{ deploy_archive_dest_permissions.folder_permission }} {} +"
+  tags:
+    - molecule-idempotence-notest
+
+- name: Deploy archive | Set file permissions
+  ansible.builtin.command: "find {{ deploy_archive_dest }} -type f -exec chmod {{ deploy_archive_dest_permissions.file_permission }} {} +"
   tags:
     - molecule-idempotence-notest
 


### PR DESCRIPTION
Permissions on target system depends on how was build the archive. User might want to be able to set them up